### PR TITLE
Added styling to .button--link to stop the button link text wrapping …

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -29,9 +29,11 @@
   &--link {
     padding: 0;
     > * {
-      display: block;
+      display: flex;
+      white-space: nowrap;
       padding: 15px 38px;
       text-decoration: none;
+      overflow-wrap: none;
     }
   }
 


### PR DESCRIPTION
…on certain screen sizes. Button link text 'Book Now' should now not wrap.